### PR TITLE
Makes setup regexes work across more systems

### DIFF
--- a/scripts/setup-shell.sh
+++ b/scripts/setup-shell.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Setup argc-completions in the shell.
-
+shopt -s extglob
 set -e
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"


### PR DESCRIPTION
On my OS (macOS 14.4.1) the current install script fails with the following error when run:

```
./setup-shell.sh: line 10: syntax error in conditional expression: unexpected token `('
```

That's because this regex syntax isn't supported in bash by default (at list not my default bash). 

This line fixes it — after adding it, the install script runs without issue.